### PR TITLE
Job model

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2966,6 +2966,7 @@ name = "scanner"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "csv",
  "libminer",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri = { version = "1.1", features = ["api-all", "clipboard", "dialog"] }
 tokio = { version = "1.21.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+async-trait = "0.1.58"
 
 libminer = { path = "../../libminer", features = ["all", "vendored-openssl"] }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "macros", "sqlite", "offline"] }

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,0 +1,7 @@
+Rust backend supporting the scanning interface
+
+Flow for jobs should be as follows
+* Tauri invokes task
+* Invoked rust function sets the current working job state and runs the task
+* Task should asynchronously report progress and results to the frontend
+* Invoked rust function should not complete before the task is complete

--- a/src-tauri/src/db/config.rs
+++ b/src-tauri/src/db/config.rs
@@ -1,0 +1,56 @@
+use serde::{Serialize, Deserialize};
+use sqlx::sqlite::SqlitePool;
+use anyhow::Result;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct Config {
+    pub refreshRate: u64,
+    pub maxConnections: usize,
+    pub connectionTimeout: u64,
+    pub readTimeout: u64,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        Self {
+            refreshRate: 30,
+            maxConnections: 500,
+            connectionTimeout: 10,
+            readTimeout: 15,
+        }
+    }
+
+    pub async fn load(db: &SqlitePool) -> Result<Self> {
+        let row = sqlx::query!("SELECT * FROM config")
+            .fetch_one(db)
+            .await;
+        match row {
+            Err(sqlx::Error::RowNotFound) | Err(sqlx::Error::Database(_)) => {
+                let default = Config::new();
+                sqlx::query!("CREATE TABLE IF NOT EXISTS config (
+                    id INTEGER PRIMARY KEY NOT NULL,
+                    key TEXT NOT NULL UNIQUE,
+                    value TEXT NOT NULL
+                );")
+                    .execute(db)
+                    .await?;
+                default.save(db).await?;
+                Ok(default)
+            }
+            Ok(row) => {
+                Ok(serde_json::from_str(&row.value)?)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn save(&self, db: &SqlitePool) -> Result<()> {
+        let serial = serde_json::to_string(self)?;
+        sqlx::query!("UPDATE config SET value = ? WHERE key = 'json'",
+            serial
+        )
+            .execute(db)
+            .await?;
+        Ok(())
+    }
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2,9 +2,11 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::sqlite::SqlitePool;
 
 pub mod models;
+mod config;
 pub use models::can::DbCan;
 pub use models::miner::DbMiner;
 pub use models::rack::DbRack;
+pub use config::Config;
 
 pub async fn connect() -> Result<SqlitePool, sqlx::Error> {
     let opts = SqliteConnectOptions::new()

--- a/src-tauri/src/jobs.rs
+++ b/src-tauri/src/jobs.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 use std::ops::Deref;
-use std::ops::DerefMut;
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -79,13 +78,6 @@ impl Deref for Job {
     }
 }
 
-impl DerefMut for Job {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            Job::Scan(job) => job,
-        }
-    }
-}
 pub struct JobRunner {
     tasks: Vec<Pin<Box<dyn Future<Output = Result<()>> + Send>>>,
     cancel: broadcast::Sender<()>,
@@ -95,7 +87,7 @@ pub struct JobRunner {
 impl JobRunner {
     /// Create a new job wrapper
     /// Primarily to handle the cancellation of jobs
-    /// Returns a JobWrapper and a oneshot::Sender
+    /// Returns a JobRunner and a broadcast::Sender
     pub async fn new(job: Job, db: &SqlitePool, app: AppHandle, client: Client) -> Result<(Self, broadcast::Sender<()>)> {
         let tasks = job.prepare(&db, app.clone(), client).await?;
         let (cancel, _) = broadcast::channel(1);

--- a/src-tauri/src/jobs.rs
+++ b/src-tauri/src/jobs.rs
@@ -39,7 +39,7 @@ impl Progress {
 
     fn increment(&mut self) -> Result<()> {
         self.done += 1;
-        self.value = (self.done as f64 / self.max as f64) * 100.0;
+        self.value = self.done as f64 / self.max as f64;
         self.app.emit_all("progress", self as &Progress)?;
         Ok(())
     }
@@ -116,9 +116,7 @@ impl JobRunner {
             futures.push(
                 tokio::spawn(async move {
                     tokio::select! {
-                        _ = cancel.recv() => {
-                            println!("Cancelled");
-                        }
+                        _ = cancel.recv() => {}
                         _ = task => {
                             progress.lock().await.increment().unwrap();
                         }

--- a/src-tauri/src/jobs.rs
+++ b/src-tauri/src/jobs.rs
@@ -1,0 +1,117 @@
+use async_trait::async_trait;
+use sqlx::sqlite::SqlitePool;
+use tauri::AppHandle;
+use libminer::Client;
+use serde::{Serialize, Deserialize};
+use anyhow::Result;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tauri::Manager;
+
+mod scan;
+
+#[derive(Serialize, Debug, Clone)]
+struct Progress {
+    value: f64,
+    max: usize,
+    done: usize,
+    job: String,
+    #[serde(skip)]
+    app: AppHandle,
+}
+
+impl Progress {
+    fn new(app: AppHandle, job: String, max: usize) -> Self {
+        Self {
+            value: 0.0,
+            max,
+            done: 0,
+            job,
+            app,
+        }
+    }
+
+    fn increment(&mut self) -> Result<()> {
+        self.done += 1;
+        self.value = (self.done as f64 / self.max as f64) * 100.0;
+        self.app.emit_all("progress", *self)?;
+        Ok(())
+    }
+
+    fn emit(&self) -> Result<()> {
+        self.app.emit_all("progress", *self)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait JobDef {
+    /// This is called prior to the job being run
+    /// It should load the required data from the database
+    async fn prepare(&mut self, db: &SqlitePool) -> Result<()>;
+
+    /// Job will be passed all stateful arguments
+    /// cancel is a oneshot channel that will be triggered if the job is cancelled by the user
+    /// the job *must* cancel
+    /// The job should increment progress as necessary
+    /// The job should emit results through app.emit_all
+    async fn run(
+        &self,
+        app: AppHandle,
+        db: &SqlitePool,
+        client: Client,
+        cancel: oneshot::Receiver<()>,
+        progress: &Mutex<Progress>
+    ) -> Result<()>;
+
+    /// This should report the total number of steps the job will take
+    fn todo_count(&self) -> usize;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "job", content = "data")]
+pub enum Job {
+    Scan(scan::ScanJob),
+}
+
+impl Job {
+    fn inner(self) -> Box<dyn JobDef + Sync + Send> {
+        match self {
+            Job::Scan(scan) => Box::new(scan),
+        }
+    }
+}
+
+pub struct JobWrapper {
+    job: Job,
+    recv: oneshot::Receiver<()>,
+    progress: Mutex<Progress>,
+}
+
+impl JobWrapper {
+    /// Create a new job wrapper
+    /// Primarily to handle the cancellation of jobs
+    /// Returns a JobWrapper and a oneshot::Sender
+    pub fn new(job: Job, app: AppHandle) -> (Self, oneshot::Sender<()>) {
+        let todo_count = job.inner().todo_count();
+        let (cancel, recv) = oneshot::channel();
+        let progress = Mutex::new(Progress::new(app.clone(), "".to_string(), todo_count));
+        (
+            Self {
+                job,
+                recv,
+                progress,
+            },
+            cancel
+        )
+    }
+
+    pub async fn prepare(&mut self, db: &SqlitePool) -> Result<()> {
+        self.job.inner().prepare(db).await
+        self.progress.lock().await.emit()
+    }
+
+    pub async fn run(self, app: AppHandle, db: &SqlitePool, client: Client) -> Result<()> {
+        self.job.inner().run(app, db, client, self.recv, &self.progress).await
+    }
+}

--- a/src-tauri/src/jobs/scan.rs
+++ b/src-tauri/src/jobs/scan.rs
@@ -1,0 +1,153 @@
+use async_trait::async_trait;
+use sqlx::sqlite::SqlitePool;
+use tauri::AppHandle;
+use libminer::Client;
+use serde::{Serialize, Deserialize};
+use anyhow::Result;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tauri::Manager;
+use tracing::error;
+
+use crate::models::{Miner, MinerEvent};
+use crate::db;
+use super::{Progress, JobDef};
+
+async fn scan_miner(client: Client, ip: &str) -> Miner {
+    let mut ret = Miner {
+        ip: ip.to_string(),
+        make: None,
+        model: None,
+        hashrate: None,
+        temp: None,
+        fan: None,
+        uptime: None,
+        mac: None,
+        errors: vec![],
+        pools: vec![],
+        sleep: false,
+    };
+    if let Ok(mut miner) = client.get_miner(ip, None).await {
+        ret.make = Some(miner.get_type().to_string());
+        if let Err(_) = miner.auth("admin", "admin").await {
+            miner.auth("root", "root").await;
+        }
+        ret.model = Some(miner.get_model().await.unwrap_or("Unknown".to_string()));
+        ret.hashrate = Some(miner.get_hashrate().await.unwrap_or(0.0));
+        ret.temp = miner.get_temperature().await.ok();
+        ret.fan = miner.get_fan_speed().await.ok();
+        ret.mac = Some(miner.get_mac().await.unwrap_or("Unknown".to_string()));
+        ret.pools = miner.get_pools().await.unwrap_or(vec![]);
+        if ret.hashrate == Some(0.0) {
+            // Try to get errors up to 3 times
+            for _ in 0..3 {
+                if let Ok(errors) = miner.get_errors().await {
+                    ret.errors = errors;
+                    break;
+                }
+            }
+        }
+        if !ret.pools.is_empty() && ret.pools[0].url.is_empty() {
+            ret.errors.push("No pool set".to_string());
+        }
+        // Lastly check if miner is sleeping
+        if let Ok(sleep) = miner.get_sleep().await {
+            ret.sleep = sleep;
+        }
+    }
+    ret
+}
+
+async fn scan_emit(miner: &MinerScan, client: Client, app: tauri::AppHandle, progress: &Mutex<Progress>) -> Result<()>{
+    let result = scan_miner(client.clone(), &miner.ip).await;
+    app.emit_all("miner", MinerEvent {
+        rack: miner.rack,
+        row: miner.row,
+        index: miner.index,
+        miner: result,
+    })?;
+    // Scoping mutex guards is just good practice
+    {
+        let mut progress = progress.lock().await;
+        progress.increment()?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct MinerScan {
+    rack: i64,
+    row: i64,
+    index: i64,
+    ip: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ScanJob {
+    pub can: i64,
+    #[serde(skip)]
+    pub todo: Vec<MinerScan>,
+}
+
+#[async_trait]
+impl JobDef for ScanJob {
+    async fn prepare(&mut self, db: &SqlitePool) -> Result<()> {
+        let mut can = db::DbCan::get(db, self.can).await.map_err(|e| e.to_string())?;
+        can.load_racks(db).await.map_err(|e| e.to_string())?;
+        let mut todo = Vec::new();
+        for rack in &can.racks {
+            for row in &rack.miners {
+                for miner in row {
+                    todo.push(MinerScan {
+                        rack: rack.index,
+                        row: miner.row,
+                        index: miner.index,
+                        ip: miner.ip.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn run(
+        &self,
+        app: AppHandle,
+        db: &SqlitePool,
+        client: Client,
+        cancel: oneshot::Receiver<()>,
+        progress: &Mutex<Progress>
+    ) -> Result<()> {
+        let mut futures = Vec::new();
+        for scan in &self.todo {
+            futures.push(
+                tokio::spawn(scan_emit(scan, client.clone(), app.clone(), progress))
+            )
+        }
+        // We're gonna spawn out a separate task to wait for each JoinHandle
+        let scanwait = tokio::spawn(async move {
+            for future in futures {
+                if let Err(e) = future.await {
+                    error!("Scan future failed: {}", e);
+                }
+            }
+        });
+        // Select between the scanwait task and the cancel channel
+        tokio::select! {
+            _ = scanwait => {
+                Ok(())
+            }
+            _ = cancel => {
+                // Abort all join handles
+                for future in futures {
+                    future.abort();
+                }
+                Err(anyhow::format_err!("Scan cancelled"))
+            }
+        }
+    }
+
+    fn todo_count(&self) -> usize {
+        self.todo.len()
+    }
+}

--- a/src-tauri/src/jobs/scan.rs
+++ b/src-tauri/src/jobs/scan.rs
@@ -4,17 +4,13 @@ use tauri::AppHandle;
 use libminer::Client;
 use serde::{Serialize, Deserialize};
 use anyhow::Result;
-use tokio::sync::broadcast;
-use tokio::sync::{Mutex};
 use tauri::Manager;
-use tracing::{error, warn, info};
-use std::sync::Arc;
 use std::pin::Pin;
 use std::future::Future;
 
 use crate::models::{Miner, MinerEvent};
 use crate::db;
-use super::{Progress, JobDef};
+use super::JobDef;
 
 async fn scan_miner(client: Client, ip: &str) -> Miner {
     let mut ret = Miner {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,6 @@ use tauri::{State, Manager};
 use anyhow::Result;
 use tokio::sync::Mutex;
 use tokio::sync::broadcast;
-use tracing::info;
 
 mod db;
 mod frontier;
@@ -46,7 +45,7 @@ impl JobState {
 
     async fn cancel(&mut self) -> Result<()> {
         if let Some(cancel) = self.cancel.take() {
-            info!("Sent: {}", cancel.send(()).map_err(|_| anyhow::anyhow!("Failed to cancel job"))?);
+            cancel.send(()).map_err(|_| anyhow::anyhow!("Failed to cancel job"))?;
         }
         Ok(())
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ use tokio::sync::Mutex;
 
 mod db;
 mod frontier;
+use db::Config;
 
 #[derive(Serialize)]
 struct Can {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,0 +1,2 @@
+mod miner;
+pub use miner::*;

--- a/src-tauri/src/models/miner.rs
+++ b/src-tauri/src/models/miner.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+use crate::db::DbCan;
+use libminer::Pool;
+
+#[derive(Serialize)]
+pub struct Can {
+    id: i64,
+    name: String,
+}
+
+impl From<DbCan> for Can {
+    fn from(can: DbCan) -> Self {
+        Self {
+            id: can.id,
+            name: can.name,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct Miner {
+    pub ip: String,
+    pub make: Option<String>,
+    pub model: Option<String>,
+    pub mac: Option<String>,
+    pub hashrate: Option<f64>,
+    pub temp: Option<f64>,
+    pub fan: Option<Vec<u32>>,
+    pub uptime: Option<f64>,
+    pub errors: Vec<String>,
+    pub pools: Vec<Pool>,
+    pub sleep: bool,
+}
+
+#[derive(Serialize, Debug)]
+pub struct Rack {
+    pub name: String,
+    pub width: i64,
+    pub height: i64,
+    pub miners: Vec<Vec<Miner>>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct MinerEvent {
+    pub rack: i64,
+    pub row: i64,
+    pub index: i64,
+    pub miner: Miner,
+}

--- a/src/lib/Controls.svelte
+++ b/src/lib/Controls.svelte
@@ -46,16 +46,21 @@
   async function scan() {
     scanning = true;
     scanned = selected;
-    let res = await invoke("scan_miners_async", { can: selected.id });
+    //let res = await invoke("scan_miners_async", { can: selected.id });
+    let res = await invoke("run_job", { job: { job: "Scan", can: selected.id }});
     scanning = false;
     return res;
   }
 
   async function scanMiners() {
-    await invoke("gen_empty_can", { can: selected.id }).then((resp: any) => {
-      miners = resp.racks;
-      scan();
-    });
+      if (!scanning) {
+        invoke("gen_empty_can", { can: selected.id }).then((resp: any) => {
+            miners = resp.racks;
+            scan();
+        });
+      } else {
+        await invoke("cancel_job");
+      }
   }
 
   async function monitorMiners() {
@@ -97,7 +102,7 @@
       class="dropdown"
       disabled = {scanning || monitor}
     />
-    <button on:click={scanMiners} {disabled}>Scan</button>
+    <button on:click={scanMiners} disabled={monitor || !selected}> {scanning ? "Cancel" : "Scan" }</button>
     <button on:click={monitorMiners} disabled={disabled2}>{monitor ? "Stop Monitoring" : "Monitor"}</button>
     <button on:click={settingsDialog} disabled={scanning || monitor}>Settings</button>
   </div>


### PR DESCRIPTION
- Implemented cancellation of jobs
- Job lock prevents more than 1 job running on the backend
- All jobs now created through the `run_job` Tauri command
- Generic JobRunner handles running/cancellation of jobs